### PR TITLE
chore: add path/filepath import at media.go

### DIFF
--- a/media.go
+++ b/media.go
@@ -10,9 +10,10 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
-  "net/url"
+	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 )
 


### PR DESCRIPTION
fix: fix missing import for upload permanent image